### PR TITLE
fix division precision

### DIFF
--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -182,7 +182,7 @@ function divideAbsoluteValues(sign, first, second, precision, roundingMode) {
     var leftover = first;
     var calculationPrecision = precision + 3;
     var accumulator = new BigNumber(Constants.POSITIVE, [0], 0, calculationPrecision, roundingMode);
-    for(var i = 0; i < 500; i++) {
+    for(var i = 0; i < precision; i++) {
         var quotient = getIterationQuotient(leftover, second, calculationPrecision, roundingMode);
         var subtract = multiplyAbsoluteValues(Constants.POSITIVE, second, quotient, calculationPrecision, Constants.ROUNDING_MODE_DOWN);
         leftover = subtractAbsoluteValues(Constants.POSITIVE, leftover, subtract, calculationPrecision, roundingMode);

--- a/test/arithmetics.spec.js
+++ b/test/arithmetics.spec.js
@@ -118,4 +118,12 @@ describe('Arithmetic Specification', function() {
         expect(result.getScale()).to.equal(2);
     });
 
+    it('should divide in correct precision, 10000 if needed', function() {
+        var first = parser.parse("1");
+        var second = parser.parse("3");
+        var result = Arithmetic.divide(first, second, 10000, Constants.ROUNDING_MODE_HALF_UP);
+        console.log("Division result: " + JSON.stringify(result));
+        expect(result.getValue().length).to.equal(10000);
+    });
+
 });


### PR DESCRIPTION
For a simple puzzle I used the lib and found the precision of division is (very) limited, something I didn't expect. In my case precision stopped at 670 decimals or something, without any warning whatsoever. This change fixes that. (for division)